### PR TITLE
Fix type annotation for LineItemType enum

### DIFF
--- a/lib/Model/LineItemCreate.php
+++ b/lib/Model/LineItemCreate.php
@@ -508,7 +508,7 @@ class LineItemCreate implements ModelInterface, ArrayAccess
     /**
      * Gets type
      *
-     * @return \PostFinanceCheckout\Sdk\Model\LineItemType
+     * @return \PostFinanceCheckout\Sdk\Model\LineItemType::*
      */
     public function getType()
     {
@@ -518,7 +518,7 @@ class LineItemCreate implements ModelInterface, ArrayAccess
     /**
      * Sets type
      *
-     * @param \PostFinanceCheckout\Sdk\Model\LineItemType $type 
+     * @param \PostFinanceCheckout\Sdk\Model\LineItemType::* $type 
      *
      * @return $this
      */


### PR DESCRIPTION
The annotation says it would expect an instance of LineItemType. But it expects a string (a constant from the LineItemType).
This currently fails any autocomplete and static analysis.

Using LineItemType::* fixes this as allowed by phpstan, see https://phpstan.org/writing-php-code/phpdoc-types#literals-and-constants

But in general the same problem seems to apply to all enums in this library, e.g. also TransactionState.
Is this generated code? Then it needs to be fixed in the generator I assume.