### PR TITLE
chore: upgrade php-jwt to ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "firebase/php-jwt": "^6.8",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.7",
         "guzzlehttp/psr7": "^2.5"
     },


### PR DESCRIPTION
firebase/php-jwt ^6.8 contains security threats that are fixed by ^7.0 